### PR TITLE
DRAFT: Refactor/Mods

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -33,9 +33,9 @@ use web::{download_game, get_vu_info, VeniceEndpointData};
 mod mods;
 use mods::{
     get_mod_names_in_cache, get_mod_names_in_loadout, import_mod_folder_to_cache,
-    import_zipped_mod_to_cache, install_mod_to_loadout_from_cache,
-    make_cache_folder_names_same_as_mod_json_names, open_mod_with_vscode, remove_mod_from_cache,
-    remove_mod_from_loadout,
+    import_mod_folder_to_loadout, import_zipped_mod_to_cache, import_zipped_mod_to_loadout,
+    install_mod_to_loadout_from_cache, make_cache_folder_names_same_as_mod_json_names,
+    open_mod_with_vscode, remove_mod_from_cache, remove_mod_from_loadout,
 };
 
 mod speed_calc;
@@ -590,6 +590,8 @@ pub fn run() {
             get_mod_names_in_cache,
             import_zipped_mod_to_cache,
             import_mod_folder_to_cache,
+            import_zipped_mod_to_loadout,
+            import_mod_folder_to_loadout,
             remove_mod_from_cache,
             edit_loadout,
             import_loadout_from_path,

--- a/src/api.ts
+++ b/src/api.ts
@@ -164,8 +164,36 @@ export async function importZippedModToCache(modLocation: string): Promise<boole
   return status
 }
 
+export async function importZippedModToLoadout({
+  modLocation,
+  loadoutName,
+}: {
+  modLocation: string
+  loadoutName: string
+}): Promise<boolean> {
+  const status = (await invoke(rust_fns.import_zipped_mod_to_loadout, {
+    modLocation,
+    loadoutName,
+  })) as boolean
+  return status
+}
+
 export async function importModFolderToCache(modLocation: string): Promise<boolean> {
   const status = (await invoke(rust_fns.import_mod_folder_to_cache, { modLocation })) as boolean
+  return status
+}
+
+export async function importModFolderToLoadout({
+  modLocation,
+  loadoutName,
+}: {
+  modLocation: string
+  loadoutName: string
+}): Promise<boolean> {
+  const status = (await invoke(rust_fns.import_mod_folder_to_loadout, {
+    modLocation,
+    loadoutName,
+  })) as boolean
   return status
 }
 

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -38,6 +38,8 @@ export enum rust_fns {
   get_mod_names_in_cache = 'get_mod_names_in_cache',
   import_zipped_mod_to_cache = 'import_zipped_mod_to_cache',
   import_mod_folder_to_cache = 'import_mod_folder_to_cache',
+  import_zipped_mod_to_loadout = 'import_zipped_mod_to_loadout',
+  import_mod_folder_to_loadout = 'import_mod_folder_to_loadout',
   remove_mod_from_cache = 'remove_mod_from_cache',
   edit_loadout = 'edit_loadout',
   import_loadout_from_path = 'import_loadout_from_path',

--- a/src/routes/Mods/components/DiscoverMods.tsx
+++ b/src/routes/Mods/components/DiscoverMods.tsx
@@ -41,7 +41,7 @@ function DiscoverMods() {
         </a>
       </div>
       <div className="flex justify-center gap-8">
-        <ImportModsSheet />
+        <ImportModsSheet importToLoadout={false} />
       </div>
     </div>
   )

--- a/src/routes/Mods/components/ImportModsSheet/ImportModsSheet.tsx
+++ b/src/routes/Mods/components/ImportModsSheet/ImportModsSheet.tsx
@@ -6,7 +6,7 @@ import { ModFolderImport } from './ModFolderImport'
 import { ZippedModImport } from './ZippedModImport'
 import clsx from 'clsx'
 
-export default function ImportModsSheet() {
+export default function ImportModsSheet({ importToLoadout }: { importToLoadout: boolean }) {
   const [sheetOpen, setSheetOpen] = useState(false)
   const [zipActive, setZipActive] = useState(false)
   const { t } = useTranslation()
@@ -26,8 +26,10 @@ export default function ImportModsSheet() {
         <div className="flex justify-center gap-8">
           <div
             className={clsx(
-              'flex min-h-20 min-w-20 flex-col items-center justify-center rounded-md border bg-secondary p-4 transition hover:cursor-pointer hover:bg-secondary/80',
+              'min-h-20 min-w-20 flex-col items-center justify-center rounded-md border bg-secondary p-4 transition hover:cursor-pointer hover:bg-secondary/80',
               zipActive && 'border-cyan-500',
+              importToLoadout && 'hidden',
+              !importToLoadout && 'flex',
             )}
             onClick={() => {
               setZipActive(() => true)
@@ -47,8 +49,8 @@ export default function ImportModsSheet() {
             {t('mods.import.sheet.folder')} <Folder />
           </div>
         </div>
-        {zipActive && <ZippedModImport />}
-        {!zipActive && <ModFolderImport />}
+        {zipActive && !importToLoadout && <ZippedModImport importToLoadout={importToLoadout} />}
+        {!zipActive && <ModFolderImport importToLoadout={importToLoadout} />}
       </SheetContent>
     </Sheet>
   )

--- a/src/routes/Servers/components/ManageModsInServerSheet/ManageModsInServerSheet.tsx
+++ b/src/routes/Servers/components/ManageModsInServerSheet/ManageModsInServerSheet.tsx
@@ -6,6 +6,7 @@ import { useTranslation } from 'react-i18next'
 import { TooltipWrapper } from '@/components/TooltipWrapper'
 import { CacheModContainer } from './mods/CacheModContainer'
 import { LoadoutModContainer } from './mods/LoadoutModContainer'
+import ImportModsSheet from '@/routes/Mods/components/ImportModsSheet/ImportModsSheet'
 
 export function ManageModsInServerSheet({ loadout }: { loadout: LoadoutJSON }) {
   const [sheetOpen, setSheetOpen] = useState(false)
@@ -22,6 +23,9 @@ export function ManageModsInServerSheet({ loadout }: { loadout: LoadoutJSON }) {
       </SheetTrigger>
       <SheetContent className="overflow-y-scroll">
         <div className="m-auto flex max-w-screen-lg flex-col gap-8">
+          <div className="m-auto w-fit">
+            <ImportModsSheet importToLoadout={true} />
+          </div>
           <LoadoutModContainer loadout={loadout} />
 
           <CacheModContainer loadout={loadout} />


### PR DESCRIPTION
## What?
- Make it possible to import mods directly into a loadout
- Improve the rust code related to mod management
## Why?
- It's annoying to manage mods right now. Should be able to import directly into a loadout.
- There are strange behaviors currently
   - Install a mod from Cache -> Loadout
   - backend copies the folder and pushes to the loadoutJSON modlist
   - backend loops over ALL mod folder names in that loadout and tries to rename all of them
     - Success: bing chilling
     - Failure: deletes the failed to rename folder, but loadoutJSON modlist is not updated